### PR TITLE
GenerateCSR: Move to 2048 Key Bit Length only

### DIFF
--- a/app/common/services/constants.js
+++ b/app/common/services/constants.js
@@ -117,7 +117,7 @@ window.angular && (function(angular) {
         HOST_OFF_IMMEDIATE: 1000 * 60 * 2  // 2 mins
       },
       CERTIFICATE: {
-        KEY_BIT_LENGTH: [512, 1024, 2048, 4096, 8192, 16384],
+        KEY_BIT_LENGTH: [2048],
         KEY_USAGE: [
           'ClientAuthentication', 'CodeSigning', 'CRLSigning',
           'DataEncipherment', 'DecipherOnly', 'DigitalSignature',


### PR DESCRIPTION
The backend change to move to 2048 length only:
https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/19421/48..56/redfish-core/lib/certificate_service.hpp
https://github.com/ibm-openbmc/bmcweb/pull/13/commits/4c8ff6947cb5e0daae46800576af0eff854b9280

The GUI change is here:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/22468/19..20

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>