### PR TITLE
SW476940: Add searchable properties to event log filter

### DIFF
--- a/app/common/services/api-utils.js
+++ b/app/common/services/api-utils.js
@@ -906,18 +906,12 @@ window.angular && (function(angular) {
                                   content.data[key].AdditionalData.join('\n'),
                               type: content.data[key].Message,
                               selected: false,
-                              search_text:
-                                  ('#' + content.data[key].Id + ' ' +
-                                   severityCode + ' ' +
-                                   content.data[key].Message + ' ' +
-                                   content.data[key].Severity + ' ' +
-                                   content.data[key].AdditionalData.join(' '))
-                                      .toLowerCase(),
                               meta: false,
                               confirm: false,
                               related_items: relatedItems,
                               eventID: eventID,
                               description: description,
+                              logId: '#' + content.data[key].Id,
                               data: {key: key, value: content.data[key]}
                             },
                             content.data[key]));

--- a/app/server-health/controllers/log-controller.js
+++ b/app/server-health/controllers/log-controller.js
@@ -110,22 +110,34 @@ window.angular && (function(angular) {
           };
 
           $scope.filterBySearchTerms = function(log) {
-            if (!$scope.searchItems.length) return true;
+            const searchableProperties = [
+              'eventID', 'severity_code', 'description', 'priority',
+              'additional_data', 'type', 'logId'
+            ];
+            let matched = false;
 
-            for (var i = 0, length = $scope.searchItems.length; i < length;
-                 i++) {
-              if (log.search_text.indexOf(
-                      $scope.searchItems[i].toLowerCase()) == -1)
-                return false;
+            if (!$scope.searchItems.length) return true;
+            for (const searchTerm of $scope.searchItems) {
+              if (matched) {
+                break;
+              }
+              for (const prop of searchableProperties) {
+                const propVal = log[prop];
+                if (propVal &&
+                    propVal.toLowerCase().indexOf(searchTerm) !== -1) {
+                  matched = true;
+                  break;
+                }
+              }
             }
-            return true;
+            return matched;
           };
 
           $scope.addSearchItem = function(searchTerms) {
             var terms = searchTerms.split(' ');
             terms.forEach(function(searchTerm) {
               if ($scope.searchItems.indexOf(searchTerm) == -1) {
-                $scope.searchItems.push(searchTerm);
+                $scope.searchItems.push(searchTerm.toLowerCase());
               }
             });
           };


### PR DESCRIPTION
This fixes SW476940, "Unable to search event logs using event log code".

Upstream: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/25809

The current event log search doesn't match inputs like
the event id, severity or priority.
This commit will add additional searchable log properties
to the search filter so users can enter search terms like
'High' or 'Error' or other visible keywords.

Signed-off-by: Yoshie Muranaka <yoshiemuranaka@gmail.com>
Change-Id: I569112468a9f97034449799f407137f1651cec16
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>