### PR TITLE
FW695713: Fix LDAP service update error

### DIFF
--- a/app/access-control/controllers/ldap-controller.html
+++ b/app/access-control/controllers/ldap-controller.html
@@ -47,7 +47,7 @@
               <dd>{{ldapCertificate.ValidNotAfter | localeDate }}</dd>
             </dl>
             <p class="ldap__certificate-info" ng-if="!ldapCertificate || !caCertificate">
-              <span>{{data.ValidNotAfter}}CA certificate and a LDAP certificate are required. One or more are missing.</span>
+              <span>A CA certificate and LDAP certificate are required. One or more are missing.</span>
             </p>
             <p ng-if="!ldapCertificate || !caCertificate" class="ldap__certificate-info">
               <a ng-class="{'disabled': !ldapProperties.ServiceEnabled}" ng-href="{{ldapProperties.ServiceEnabled ? '#/access-control/ssl-certificates' : ''}}">Go to SSL certificates</a>

--- a/app/access-control/controllers/ldap-controller.js
+++ b/app/access-control/controllers/ldap-controller.js
@@ -29,49 +29,52 @@ window.angular && (function(angular) {
       $scope.loadLdap = function() {
         $scope.loading = true;
         $scope.submitted = false;
-        const getLdapProperties = APIUtils.getAllUserAccountProperties().then(
-            function(data) {
-              const serviceEnabled = data.LDAP.ServiceEnabled ||
-                  data.ActiveDirectory.ServiceEnabled;
-              const ldapServiceEnabled = data.LDAP.ServiceEnabled;
-              const adServiceEnabled = data.ActiveDirectory.ServiceEnabled;
-              const enabledServiceType = getEnabledServiceType(data);
-              const serviceAddresses = getServiceAddresses(data);
-              const useSSL = getUseSSL(data);
-              const userName = getUsername(data);
-              const baseDistinguishedNames = getBaseDistinguishedNames(data);
-              const groupsAttribute = getGroupsAttribute(data);
-              const usernameAttribute = getUsernameAttribute(data);
-              const authenticationType = getAuthenticationType(data);
-              const roleGroups = getRoleGroups(data);
+        const ldapAccountProperties =
+            APIUtils.getAllUserAccountProperties().then(
+                function(data) {
+                  const serviceEnabled = data.LDAP.ServiceEnabled ||
+                      data.ActiveDirectory.ServiceEnabled;
+                  const ldapServiceEnabled = data.LDAP.ServiceEnabled;
+                  const adServiceEnabled = data.ActiveDirectory.ServiceEnabled;
+                  const enabledServiceType = getEnabledServiceType(data);
+                  const serviceAddresses = getServiceAddresses(data);
+                  const useSSL = getUseSsl(data);
+                  const userName = getUsername(data);
+                  const baseDistinguishedNames =
+                      getBaseDistinguishedNames(data);
+                  const groupsAttribute = getGroupsAttribute(data);
+                  const usernameAttribute = getUsernameAttribute(data);
+                  const authenticationType = getAuthenticationType(data);
+                  const roleGroups = getRoleGroups(data);
 
 
-              return {
-                'ServiceEnabled': serviceEnabled,
-                'LDAPServiceEnabled': ldapServiceEnabled,
-                'ADServiceEnabled': adServiceEnabled,
-                'EnabledServiceType': enabledServiceType,
-                'ServiceAddresses': serviceAddresses,
-                'useSSL': useSSL,
-                'Username': userName,
-                'BaseDistinguishedNames': baseDistinguishedNames,
-                'GroupsAttribute': groupsAttribute,
-                'UsernameAttribute': usernameAttribute,
-                'AuthenticationType': authenticationType,
-                'RoleGroups': roleGroups
-              };
-            },
-            function(error) {
-              console.log(JSON.stringify(error));
-            });
+                  return {
+                    'ServiceEnabled': serviceEnabled,
+                    'LDAPServiceEnabled': ldapServiceEnabled,
+                    'ADServiceEnabled': adServiceEnabled,
+                    'EnabledServiceType': enabledServiceType,
+                    'ServiceAddresses': serviceAddresses,
+                    'useSSL': useSSL,
+                    'Username': userName,
+                    'BaseDistinguishedNames': baseDistinguishedNames,
+                    'GroupsAttribute': groupsAttribute,
+                    'UsernameAttribute': usernameAttribute,
+                    'AuthenticationType': authenticationType,
+                    'RoleGroups': roleGroups
+                  };
+                },
+                function(error) {
+                  console.log(JSON.stringify(error));
+                });
 
-        const lDAPCertificate =
+        const ldapCertificate =
             getCertificate('/redfish/v1/AccountService/LDAP/Certificates');
 
         const caCertificate =
             getCertificate('/redfish/v1/Managers/bmc/Truststore/Certificates/');
 
-        var promises = [getLdapProperties, lDAPCertificate, caCertificate];
+        const promises =
+            [ldapAccountProperties, ldapCertificate, caCertificate];
         $q.all(promises).then(function(results) {
           $scope.ldapProperties = results[0];
           $scope.originalLdapProperties = angular.copy(results[0]);
@@ -121,15 +124,6 @@ window.angular && (function(angular) {
                   toastService.error('Unable to update LDAP settings.');
                   console.log(JSON.stringify(error));
                 });
-      };
-
-      /**
-       * Test if URI starts with ldaps
-       * @param {string} uri
-       * @returns {boolean}
-       */
-      function isURISecure(uri) {
-        return uri.startsWith('ldaps://');
       };
 
       /**
@@ -219,14 +213,14 @@ window.angular && (function(angular) {
        * @param {Object} ldapProperties
        * @returns {boolean}
        */
-      function getUseSSL(ldapProperties) {
-        let isSSL = false;
+      function getUseSsl(ldapProperties) {
+        let useSsl = false;
         let serviceType = getEnabledServiceType(ldapProperties);
         if (serviceType) {
-          isSSL =
-              isURISecure(ldapProperties[serviceType]['ServiceAddresses'][0]);
+          const uri = ldapProperties[serviceType]['ServiceAddresses'][0];
+          useSsl = uri.startsWith('ldaps://');
         }
-        return isSSL;
+        return useSsl;
       }
 
       /**

--- a/app/common/directives/ldap-user-roles.html
+++ b/app/common/directives/ldap-user-roles.html
@@ -84,7 +84,7 @@
   <!-- LDAP Disabled Role Groups Table Row -->
   <div class="empty__logs" ng-if="roleGroups.length < 1 || !enabled">
     <p
-      ng-if="roleGroups.length < 1 && roleGroupType === 'ad' ||  roleGroupType === 'ldap'"
+      ng-if="!roleGroups.length && roleGroupType"
     >
       No role groups have been created yet.
     </p>

--- a/app/common/directives/ldap-user-roles.js
+++ b/app/common/directives/ldap-user-roles.js
@@ -41,22 +41,19 @@ window.angular && (function(angular) {
             };
 
             $scope.addRoleGroup = () => {
+              $scope.loading = true;
+
               const newGroup = {};
               newGroup.RemoteGroup = $scope.newGroup.RemoteGroup;
               newGroup.LocalRole = $scope.newGroup.LocalRole;
 
-              $scope.loading = true;
               const data = {};
-
-              if ($scope.roleGroupType == 'ldap') {
-                data.LDAP = {};
-                data.LDAP.RemoteRoleMapping = $scope.roleGroups;
-                data.LDAP.RemoteRoleMapping.push(newGroup);
-              } else {
-                data.ActiveDirectory = {};
-                data.ActiveDirectory.RemoteRoleMapping = $scope.roleGroups;
-                data.ActiveDirectory.RemoteRoleMapping.push(newGroup);
-              }
+              const roleGroups = $scope.roleGroups;
+              const roleGroupType = $scope.roleGroupType;
+              data[roleGroupType] = {};
+              data[roleGroupType]['RemoteRoleMapping'] = roleGroups;
+              data[roleGroupType]['RemoteRoleMapping'][roleGroups.length] =
+                  newGroup;
 
               APIUtils.saveLdapProperties(data)
                   .then(
@@ -82,19 +79,14 @@ window.angular && (function(angular) {
             $scope.editRoleGroup = () => {
               $scope.loading = true;
               const data = {};
-
-              if ($scope.roleGroupType == 'ldap') {
-                data.LDAP = {};
-                data.LDAP.RemoteRoleMapping = $scope.roleGroups;
-                data.LDAP.RemoteRoleMapping[$scope.selectedGroupIndex]
-                    .LocalRole = $scope.newGroup.LocalRole;
-              } else {
-                data.ActiveDirectory = {};
-                data.ActiveDirectory.RemoteRoleMapping = $scope.roleGroups;
-                data.ActiveDirectory
-                    .RemoteRoleMapping[$scope.selectedGroupIndex]
-                    .LocalRole = $scope.newGroup.LocalRole;
-              }
+              const roleGroupType = $scope.roleGroupType;
+              const roleGroups = $scope.roleGroups;
+              const localRole = $scope.newGroup.LocalRole;
+              const selectedIndex = $scope.selectedGroupIndex;
+              data[roleGroupType] = {};
+              data[roleGroupType]['RemoteRoleMapping'] = roleGroups;
+              data[roleGroupType]['RemoteRoleMapping'][selectedIndex]['LocalRole'] =
+                  localRole;
 
               APIUtils.saveLdapProperties(data)
                   .then(
@@ -111,29 +103,21 @@ window.angular && (function(angular) {
               $scope.editGroup = false;
             };
 
-            $scope.removeGroupFn = (index) => {
+            $scope.removeGroupFn = index => {
               $scope.removeGroup = true;
               $scope.selectedGroupIndex = index;
             };
 
             $scope.removeRoleGroup = () => {
               $scope.loading = true;
+              const roleGroupType = $scope.roleGroupType;
+              const roleGroups = $scope.roleGroups;
+              const selectedGroupIndex = $scope.selectedGroupIndex;
               const data = {};
-
-              if ($scope.roleGroupType == 'ldap') {
-                data.LDAP = {};
-                data.LDAP.RemoteRoleMapping = $scope.roleGroups;
-                data.LDAP.RemoteRoleMapping[$scope.selectedGroupIndex] =
-                    $scope.newGroup;
-              } else {
-                data.ActiveDirectory = {};
-                data.ActiveDirectory.RemoteRoleMapping = $scope.roleGroups;
-                data.ActiveDirectory
-                    .RemoteRoleMapping[$scope.selectedGroupIndex] =
-                    $scope.newGroup;
-              }
-
-              $scope.roleGroups[$scope.selectedGroupIndex] = null;
+              data[roleGroupType] = {};
+              data[roleGroupType]['RemoteRoleMapping'] = roleGroups;
+              data[roleGroupType]['RemoteRoleMapping'][selectedGroupIndex] =
+                  null;
 
               APIUtils.saveLdapProperties(data)
                   .then(
@@ -167,28 +151,18 @@ window.angular && (function(angular) {
 
             $scope.removeMultipleRoleGroups = () => {
               $scope.loading = true;
+              const roleGroupType = $scope.roleGroupType;
+              const roleGroups = $scope.roleGroups;
               const data = {};
-
-              if ($scope.roleGroupType == 'ldap') {
-                data.LDAP = {};
-                data.LDAP.RemoteRoleMapping = $scope.roleGroups.map((group) => {
-                  if (group['isSelected']) {
-                    return null;
-                  } else {
-                    return group;
-                  }
-                });
-              } else {
-                data.ActiveDirectory = {};
-                data.ActiveDirectory.RemoteRoleMapping =
-                    $scope.roleGroups.map((group) => {
-                      if (group['isSelected']) {
-                        return null;
-                      } else {
-                        return group;
-                      }
-                    });
-              }
+              data[roleGroupType] = {};
+              data[roleGroupType]['RemoteRoleMapping'] =
+                  roleGroups.map((group) => {
+                    if (group['isSelected']) {
+                      return null;
+                    } else {
+                      return group;
+                    }
+                  });
 
               APIUtils.saveLdapProperties(data)
                   .then(


### PR DESCRIPTION
Picking up a new patch set of this, fixes
FW695713 LDAP: Regression: op940.00-10: Operator privilege
able to change successfully, but after refresh, it shows
as "Administrator"

When a service is enabled, it must be disabled prior
to changing the service type, e.g change from OpenLDAP
to ActiveDirectory.

- Add check to determine if a service is already enabled
- Make two calls if service is already enabled. First to
  disable existing service. Second to enable updated
  service
- Remove toast message for ssl check and replace with
  error message which also keeps submit button disabled
  if the regex pattern is not met

Tested:
- Edge
- Safari
- Firefox
- Chrome
- IE 11

Signed-off-by: Derick Montague <derick.montague@ibm.com>
Change-Id: I195eeb7d1cd3621681c18f4dd9aa4414eb079c09
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>