### PR TITLE
SW477679: Fix invalid gateway toast message

### DIFF
--- a/app/configuration/controllers/network-controller.js
+++ b/app/configuration/controllers/network-controller.js
@@ -105,7 +105,8 @@ window.angular && (function(angular) {
               $scope.loading = false;
               return;
             }
-            if (!APIUtils.validIPV4IP(
+            if ($scope.interface.ipv4.values[i].Gateway &&
+                !APIUtils.validIPV4IP(
                     $scope.interface.ipv4.values[i].Gateway)) {
               toastService.error(
                   $scope.interface.ipv4.values[i].Address +


### PR DESCRIPTION
This fixes part of SW477679.
This happens only when the Gateway is set to either 0.0.0.0 or is
empty. When 0.0.0.0 is submitted, the value is not saved by the
backend and/or is not sent in the GET request resulting in an
empty gateway.

Don't validate the gateway if the gateway is empty. An empty
gateway is allowed on the backend.

Upstream: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/25923

Add check for gateway value before testing if the string is valid.
The backend seems to handle an empty gateway the same as sending
0.0.0.0. When the GET call is made after sending 0.0.0.0 as the
gateway value, the response returns an empty string. This field
seems to be an override for the default gateway input for the
interface.

Signed-off-by: Derick Montague <derick.montague@ibm.com>
Change-Id: Id6a5575e73a7c8adfff052c89bb4e8ca986d45f9
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>