### PR TITLE
SW477679: DNS: Remove workaround for empty list array

### DIFF
--- a/app/configuration/controllers/network-controller.js
+++ b/app/configuration/controllers/network-controller.js
@@ -211,11 +211,6 @@ window.angular && (function(angular) {
       }
 
       function setNameservers() {
-        // Nameservers does not allow an empty array, since we remove all empty
-        // strings above, could have an empty array. TODO: openbmc/openbmc#3240
-        if ($scope.interface.Nameservers.length == 0) {
-          $scope.interface.Nameservers.push('');
-        }
         return APIUtils
             .setNameservers(
                 $scope.selectedInterface, $scope.interface.Nameservers)


### PR DESCRIPTION
This fixes SW477679, which was caused by
https://github.com/ibm-openbmc/phosphor-networkd/commit/cd2febaa6f5ae2b102e771aac25cdb693ff34189
in an effort to fix SW472269.

Due to openbmc/openbmc/issues/3240 we were passing an array with an
empty string instead of just an empty array.
https://github.com/ibm-openbmc/phosphor-networkd/commit/cd2febaa6f5ae2b102e771aac25cdb693ff34189 now flags this empty
string as an invalid argument. Just remove the workaround.
The other choice would be to revert https://github.com/ibm-openbmc/phosphor-networkd/commit/cd2febaa6f5ae2b102e771aac25cdb693ff34189 but I think https://github.com/ibm-openbmc/phosphor-networkd/commit/cd2febaa6f5ae2b102e771aac25cdb693ff34189 is
the correct step forward. 

This experience still needs some work, no clues on the GUI that
a DNS hostname (dns.google.com) will not be accepted and the error
returned for an invalid argument is 403 forbidden.
These are beyond what we will do in OP940.

Upstream: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/26094

This workaround is no longer needed with bmcweb.

curl  -k -H "Content-Type: application/json" -X PUT \
-d '{"data": [] }' \
https://${bmc}/xyz/openbmc_project/network/eth0/attr/Nameservers
{
  "data": null,
  "message": "200 OK",
  "status": "ok"

and actually casues an error now do to
https://github.com/openbmc/phosphor-networkd/commit/5fb6c33a49ee2b9718cc9ce0f921d3b6cf38a463

curl  -k -H "Content-Type: application/json" -X PUT \
-d '{"data": [""] }' \
https://${bmc}/xyz/openbmc_project/network/eth0/attr/Nameservers
  "data": {
    "description": "xyz.openbmc_project.Common.Error.InvalidArgument"
  },
  "message": "Invalid argument was given.",

See https://github.com/openbmc/openbmc/issues/3240

Tested: Built and loaded on a Witherspoon. Added, removed,
        and edited DNS servers.
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>
Change-Id: I278489a8c4682641b61a0e5ab08fd714603b0234