### PR TITLE
Alert user of need and ability to change expired password

### DIFF
--- a/app/common/services/api-utils.js
+++ b/app/common/services/api-utils.js
@@ -487,7 +487,7 @@ window.angular && (function(angular) {
               .then(
                   function(response) {
                     if (callback) {
-                      callback(response.data);
+                      callback(response);
                     }
                   },
                   function(error) {

--- a/app/common/services/userModel.js
+++ b/app/common/services/userModel.js
@@ -16,11 +16,16 @@ window.angular && (function(angular) {
       return {
         login: function(username, password, callback) {
           APIUtils.login(username, password, function(response, error) {
-            if (response &&
-                (response.status == APIUtils.API_RESPONSE.SUCCESS_STATUS ||
-                 response.status === undefined)) {
+            // if extendedMessage is present in the response, the password is
+            // expired
+            if (response.data['extendedMessage']) {
+              callback(false, false, response.statusText);
+            } else if (
+                response.data &&
+                (response.data.status == APIUtils.API_RESPONSE.SUCCESS_STATUS ||
+                 response.data.status === undefined)) {
               sessionStorage.setItem('LOGIN_ID', username);
-              callback(true);
+              callback(true, true, response.statusText);
             } else if (
                 response && response.data && response.data.data &&
                 response.data.data.description) {

--- a/app/common/styles/elements/alerts.scss
+++ b/app/common/styles/elements/alerts.scss
@@ -17,6 +17,17 @@
   }
 }
 
+.alert-success {
+  background-color: $accent-02--02;
+  border-color: $accent-02--01;
+  border-radius: 0;
+  color: $primary-dark;
+  text-align: left;
+  .icon {
+    vertical-align: bottom;
+  }
+}
+
 .message-container {
   background-color: $background-02;
   padding: 1em 1.5em;

--- a/app/login/controllers/login-controller.html
+++ b/app/login/controllers/login-controller.html
@@ -5,35 +5,101 @@
       <h1 class="login__desc">BMC System Management</h1>
       <img src="../../assets/images/BuiltOnOpenBMC.svg" class="builton__logo" alt="Built On OpenBMC logo"/>
     </div>
-    <div class="columns large-6">
+    <!-- Login UI-->
+    <div class="columns large-6" ng-if="isPasswordValid">
       <form id="login__form" name="login__form" action="" ng-class="{'submitted' : submitted}">
         <fieldset ng-disabled="dataService.loading">
           <div class="alert alert-danger" role="alert" ng-if="invalidCredentials">
             <b>Invalid username or password.</b>
             <br>Please try again.
           </div>
+          <div class="alert alert-success" role="alert" ng-if="successPasswordChange==true">
+            <icon file="icon-on.svg" aria-hidden="true" class="expired__password__success"></icon>
+            Successfully changed password.
+          </div>
           <label for="host">BMC Host or BMC IP Address</label>
-          <input type="text" id="host" name="host" class="validate-input" ng-model="host" has-error="serverUnreachable && login__form.host.$pristine" required  autofocus ng-keydown="tryLogin(host, username, password, $event)">
+          <input type="text" id="host" name="host" class="validate-input" ng-model="host" has-error="serverUnreachable && login__form.host.$pristine"
+            required autofocus>
           <div ng-messages="login__form.host.$error" class="form-error" ng-class="{'visible' : login__form.host.$touched || submitted}">
             <p ng-message="required">Field is required</p>
             <p ng-message="hasError">Server unreachable</p>
           </div>
-
           <label for="username">Username</label>
-          <input type="text" id="username" name="username" has-error="invalidCredentials && login__form.$pristine" required ng-model="username" ng-keydown="tryLogin(host, username, password, $event)" autocomplete="off">
+          <input type="text" id="username" name="username" has-error="invalidCredentials && login__form.$pristine" required ng-model="username"
+            autocomplete="off">
           <div ng-messages="login__form.username.$error" class="form-error" ng-class="{'visible' : login__form.username.$touched || submitted}">
             <p ng-message="required">Field is required</p>
           </div>
-
           <label for="password">Password</label>
-          <input type="password" id="password" name="password" has-error="invalidCredentials && login__form.$pristine" required  ng-model="password" ng-keydown="tryLogin(host, username, password, $event)" autocomplete="off">
+          <input type="password" id="password" name="password" has-error="invalidCredentials && login__form.$pristine" required ng-model="password"
+            autocomplete="off">
           <div ng-messages="login__form.password.$error" class="form-error" ng-class="{'visible': login__form.password.$touched || submitted}">
             <p ng-message="required">Field is required</p>
           </div>
-
-          <input id="login__submit" class="btn  btn-primary full-width" type="button" value="Log in" role="button" ng-click="login(host, username, password); submitted = true; login__form.$setPristine()" ng-class="{error: error}" ng-disabled="dataService.loading">
+          <input id="login__submit" class="btn  btn-primary full-width" type="button" value="Log in" role="button" ng-click="login(host, username, password); submitted = true; login__form.$setPristine()"
+            ng-class="{error: error}" ng-disabled="dataService.loading">
         </fieldset>
       </form>
+    </div>
+    <!-- Change password UI: Expired password state-->
+    <div class="columns medium-6" ng-if="!isPasswordValid">
+      <form id="expiredPasswordForm" name="expiredPasswordForm" action="" ng-class="{'submitted': submitted}" class="login__passsword-expired">
+        <!--Password error banner-->
+        <div class="small-12 alert alert-danger" role="alert" ng-if="failedPasswordChange==false">
+          <icon file="icon-critical.svg" aria-hidden="true" class="expired-password-status-icon"></icon>
+          The password has expired and must be changed.
+        </div>
+        <!--Password change failed-->
+        <div class="small-12 alert alert-danger" role="alert" ng-if="failedPasswordChange==true">
+          <icon file="icon-critical.svg" aria-hidden="true" class="expired-password-status-icon"></icon>
+          Failed to change password.
+        </div>
+        <div class="login__passwordExpiredReadOnly">
+          <label for="host">BMC Host or BMC IP Address</label>
+          <div class="login__password-expired-host">
+            {{host}}
+          </div>
+          <label for="username">Username</label>
+          <div>{{username}}</div>
+        </div>
+        <div class="field-group-container">
+          <label for="newPassword">New Password</label>
+          <p class="label__helper-text">Must be between 8-20 characters.</p>
+          <input id="newPassword" name="newPassword" type="password" ng-minlength="8" ng-maxlength="20" ng-model="newPassword" ng-click="expiredPasswordForm.newPassword.$setTouched()"
+            password-visibility-toggle placeholder="{{
+            (
+              expiredPasswordForm.newPassword.$touched ||
+              expiredPasswordForm.confirmPassword.$touched) ? '' : '******'}}" required />
+          <div ng-messages="expiredPasswordForm.newPassword.$error" class="form-error" ng-class="{'visible': expiredPasswordForm.newPassword.$touched || submitted}">
+            <p ng-message="required">Field is required</p>
+            <p ng-show="expiredPasswordForm.newPassword.$error.minlength">Length must be between 8-20 characters</p>
+            <p ng-show="expiredPasswordForm.newPassword.$error.maxlength">Length must be between 8-20 characters</p>
+          </div>
+        </div>
+        <div class="field-group-container">
+          <label for="confirmPassword">Confirm New Password</label>
+          <input id="confirmPassword" name="confirmPassword" type="password" ng-model="passwordReset.confirmPassword" ng-click="expiredPasswordForm.confirmPassword.$setTouched()"
+            password-visibility-toggle password-confirm first-password="expiredPasswordForm.newPassword.$modelValue" placeholder="{{
+              (
+                expiredPasswordForm.newPassword.$touched ||
+                expiredPasswordForm.confirmPassword.$touched) ? '' : '******'}}" required />
+          <div class="visible form-error" ng-if="expiredPasswordForm.confirmPassword.$invalid && expiredPasswordForm.confirmPassword.$dirty">
+            <span ng-show="expiredPasswordForm.confirmPassword.$error.confirmPassword" ng-hide="expiredPasswordForm.confirmPassword.$error.required">
+              Passwords do not match</span>
+          </div>
+        </div>
+        <div class="row expired-password__btns">
+          <div class="column small-4">
+            <input id="login__submit" class="btn  btn-tertiary full-width" type="button" value="Go back" role="button" ng-class="{error: error}"
+              ng-disabled="dataService.loading" ng-click="back()">
+          </div>
+          <div class="column small-8">
+            <input id="login__submit" class="btn  btn-primary full-width" type="button" value="Change password" role="button" ng-class="{error: error}"
+              ng-disabled="expiredPasswordForm.$invalid || expiredPasswordForm.$pristine || dataService.loading" ng-click="changePassword()">
+          </div>
+        </div>
+      </form>
+      ​
     </div>
   </div>
 </div>

--- a/app/login/controllers/login-controller.js
+++ b/app/login/controllers/login-controller.js
@@ -15,45 +15,66 @@ window.angular && (function(angular) {
     'dataService',
     'userModel',
     '$location',
-    function($scope, $window, dataService, userModel, $location) {
+    'APIUtils',
+    function($scope, $window, dataService, userModel, $location, APIUtils) {
       $scope.dataService = dataService;
       $scope.serverUnreachable = false;
       $scope.invalidCredentials = false;
       $scope.host = $scope.dataService.host.replace(/^https?\:\/\//ig, '');
+      $scope.isPasswordValid = true;
+      $scope.successPasswordChange = false;
+      $scope.failedPasswordChange = false;
+      $scope.passwordReset = {};
 
-      $scope.tryLogin = function(host, username, password, event) {
-        // keyCode 13 is the 'Enter' button. If the user hits 'Enter' while in
-        // one of the 3 fields, attempt to log in.
-        if (event.keyCode === 13) {
-          $scope.login(host, username, password);
-        }
-      };
       $scope.login = function(host, username, password) {
         $scope.serverUnreachable = false;
         $scope.invalidCredentials = false;
+        $scope.username = username;
         if (!username || username == '' || !password || password == '' ||
             !host || host == '') {
           return false;
         } else {
           $scope.dataService.setHost(host);
-          userModel.login(username, password, function(status, description) {
-            if (status) {
-              $scope.$emit('user-logged-in', {});
-              var next = $location.search().next;
-              if (next === undefined || next == null) {
-                $window.location.hash = '#/overview/server';
-              } else {
-                $window.location.href = next;
-              }
-            } else {
-              if (description === 'Unauthorized') {
-                $scope.invalidCredentials = true;
-              } else {
-                $scope.serverUnreachable = true;
-              }
-            }
-          });
+          userModel.login(
+              username, password,
+              function(status, isPasswordValid, description) {
+                if (description === 'Unauthorized') {
+                  $scope.invalidCredentials = true;
+                }
+
+                else if (!isPasswordValid) {
+                  $scope.isPasswordValid = isPasswordValid;
+                } else if (status) {
+                  $scope.$emit('user-logged-in', {});
+                  var next = $location.search().next;
+                  if (next === undefined || next == null) {
+                    $window.location.hash = '#/overview/server';
+                  } else {
+                    $window.location.href = next;
+                  }
+                } else {
+                  $scope.serverUnreachable = true;
+                }
+              });
         }
+      };
+
+      $scope.changePassword = function() {
+        APIUtils
+            .updateUser(
+                $scope.username, null, $scope.passwordReset.confirmPassword)
+            .then(() => {
+              $scope.isPasswordValid = true;
+              $scope.successPasswordChange = true;
+            })
+            .catch((error) => {
+              $scope.failedPasswordChange = true;
+            })
+      };
+
+      $scope.back = function() {
+        $scope.isPasswordValid = true;
+        $scope.passwordReset.confirmPassword = '';
       };
     },
   ]);

--- a/app/login/styles/index.scss
+++ b/app/login/styles/index.scss
@@ -4,7 +4,6 @@
     @include fastTransition-all;
   }
 }
-
 .login__wrapper {
   position: relative;
   padding-top: 1em;
@@ -28,6 +27,7 @@
       margin: 0 auto;
     }
   }
+
   .builton__logo {
     max-width: 200px;
     display: block;
@@ -45,13 +45,16 @@
     @include page-transition-visibility;
   }
 }
-
-#login__form {
+#login__form,
+.login__passsword-expired {
   color: $primary-dark;
   background: transparent;
   padding: 1em 0;
   display: block;
   overflow: hidden;
+  .btn-password-toggle {
+    padding-top: 0;
+  }
   @include mediaQuery(small) {
     max-width: 50%;
     margin: 0 auto;
@@ -64,7 +67,6 @@
     padding: 0 0 0 6em;
   }
   @include fastTransition-all;
-
   input:disabled,
   input:disabled:hover {
     background-color: $background-03;
@@ -72,13 +74,26 @@
   }
 }
 
+.login__passsword-expired {
+  label {
+    margin-bottom: 0;
+  }
+
+  input {
+    height: 3em;
+    max-height: none;
+  }
+}
+
+.login__password-expired-host {
+  margin-bottom: .5rem;
+}
 .login__desc {
   text-align: center;
   font-size: 2em;
   margin: 0.5em 0 2em;
   font-weight: bold;
 }
-
 .login__server-info {
   margin-top: 2em;
   margin-left: 0;
@@ -106,10 +121,24 @@
     @include fontFamily;
   }
 }
-
 .login__status {
   color: $status-ok;
   &.error {
     color: $status-error;
+  }
+}
+
+.expired-password__btns {
+  padding-top: 1rem;
+  float: right;
+  margin-bottom: 1rem;
+}
+.login__passwordExpiredReadOnly {
+  margin-bottom: 1rem;
+}
+.expired-password-status-icon {
+  width: 1.2em;
+  svg {
+    margin-bottom: .2em;
   }
 }


### PR DESCRIPTION
Created GUI for users to change password when an
 expired password is detected.
Once user’s successfully change the password, the login
 page will appear with a success toast
and the user types in the new password to login to the bmc.
 For failed state,
a failed toast will appear and user will still be on
 the change password screen.

Testing instructions:
This requires backend changes:
 https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/25146
Once backend changes are incorporated,
Expire the password through ssh command passwd —expire root.
 Once finished testing, reset back
To original password through ssh, API or GUI.

Tested on: Chrome, Firefox and Safari
Tested with latest expired password backend.

Signed-off-by: Mira Murali <miramurali23@gmail.com>
Change-Id: If2565f946c63bac240e1c4b48b24ceaf9848b4a2
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>