### PR TITLE
Send password when saving LDAP settings

### DIFF
--- a/app/access-control/controllers/ldap-controller.js
+++ b/app/access-control/controllers/ldap-controller.js
@@ -56,6 +56,7 @@ window.angular && (function(angular) {
                     'ServiceAddresses': serviceAddresses,
                     'useSSL': useSSL,
                     'Username': userName,
+                    'Password': null,
                     'BaseDistinguishedNames': baseDistinguishedNames,
                     'GroupsAttribute': groupsAttribute,
                     'UsernameAttribute': usernameAttribute,
@@ -322,6 +323,7 @@ window.angular && (function(angular) {
         const ServiceEnabled = true;
         const Authentication = {
           Username: ldapProperties.Username,
+          Password: ldapProperties.Password,
           AuthenticationType: ldapProperties.AuthenticationType
         };
         const LDAPService = {


### PR DESCRIPTION
- Add password to the createLdapEnableRequest Authentication object to
   be sent with the LDAP payload
- Add a Password to scoped ldapProperties object

Signed-off-by: Derick Montague <derick.montague@ibm.com>
Change-Id: I63a880548bc3d9d61c4b73719457ce19222aa354