### PR TITLE
Add load network info when switch network interfaces

### DIFF
--- a/app/configuration/controllers/network-controller.js
+++ b/app/configuration/controllers/network-controller.js
@@ -35,6 +35,7 @@ window.angular && (function(angular) {
         $scope.oldInterface = JSON.parse(JSON.stringify($scope.interface));
         $scope.selectedInterface = interfaceId;
         $scope.networkDevice = false;
+        loadNetworkInfo();
       };
 
       $scope.addDNSField = function() {


### PR DESCRIPTION
When deleting an existing static ipv4 by switching network interfaces,
sometimes the id value remains undefined, which prevents the user from
properly deleting the static ipv4 because the network information on
the switch page is not load.

Since information loading is only triggered when the "Save Settings" or
"Refresh" button is clicked, adding information loading when switching
network interfaces can avoid the above problem.

Tested: When switching interfaces (from eth0 to eth1) and trying to
delete an existing static IPv4, it can be deleted normally without
operating "Remove" -> "Save Settings" twice.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>