### PR TITLE
server-overview: supporting all MACs and IPs

### DIFF
--- a/app/common/services/dataService.js
+++ b/app/common/services/dataService.js
@@ -71,9 +71,11 @@ window.angular && (function(angular) {
       this.server_id = this.getServerId();
 
       this.setNetworkInfo = function(data) {
+        var formatted = data.formatted_data || {};
         this.hostname = data.hostname;
         this.defaultgateway = data.defaultgateway;
         this.mac_address = data.mac_address;
+        this.network_interfaces = formatted.interfaces || [];
       };
 
       this.setPowerOnState = function() {

--- a/app/overview/controllers/system-overview-controller.html
+++ b/app/overview/controllers/system-overview-controller.html
@@ -46,17 +46,22 @@
                 {{ dataService.hostname }}
               </dd>
             </dl>
-            <dl class="list-pair">
-              <dt>IP addresses</dt>
-              <dd class="courier-bold" ng-repeat="ip_address in bmc_ip_addresses">
-                {{ ip_address }}
+            <dl class="list-pair" ng-repeat="(ifaceName,iface) in dataService.network_interfaces">
+              <dt>{{ifaceName | uppercase}} IP addresses</dt>
+              <dd class="courier-bold" ng-repeat="ipv4 in iface.ipv4.values">
+                IPv4: <span>{{ ipv4.Address }}</span>
+              </dd>
+              <dd class="courier-bold" ng-repeat="ipv6 in iface.ipv6.values">
+                IPv6: <span>{{ ipv6.Address | uppercase }}</span>
               </dd>
             </dl>
           </div>
           <div class="column large-6">
-            <dl class="list-pair">
-              <dt>Mac address</dt>
-              <dd class="courier-bold">{{ dataService.mac_address }}</dd>
+            <dl class="list-pair" ng-repeat="(ifaceName,iface) in dataService.network_interfaces">
+              <dt>{{ifaceName | uppercase}} Mac address</dt>
+              <dd>
+                <span>{{iface.MACAddress | uppercase}}</span>
+              </dd>
             </dl>
             <dl class="list-pair">
               <dt>Firmware Version</dt>


### PR DESCRIPTION
Show MAC and IP address information for all the present
ethernet interfaces on the server overview page.

Tested: the `webui`-overview page on a system having
2 physical ethernet interfaces shows all IP addresses
assigned to the interface and also shows MAC addresses
for each interface

```
  ETH0 IP ADDRESSES
    IPv4: 172.17.26.67
    IPv4: 169.254.28.79
    IPv6: FE80::702C:BFFF:FEDE:DEC3

  ETH1 IP ADDRESSES
    IPv4: 169.254.51.25
    IPv6: FE80::14B7:7EFF:FEF1:2EF

  ETH0 MAC ADDRESS
    72:2C:BF:DE:DE:C3

  ETH1 MAC ADDRESS
    16:B7:7E:F1:02:EF
```

End-user-impact: The server-overview page is now able to
                 display information about each ethernet's
                 MAC, IPv4 and IPv6 adresses.

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>
Change-Id: I677b645cc33bfc49c2dd91f4acc743973dc29998
(cherry picked from commit d10511f2a7fc07910d7ca517bd73331763322fa0)