### PR TITLE
Updated privilege info for ssh

### DIFF
--- a/app/access-control/directives/role-table.js
+++ b/app/access-control/directives/role-table.js
@@ -55,7 +55,7 @@ window.angular && (function(angular) {
             },
             {uiData: ['IPMI access point', check, check, check, check]},
             {uiData: ['Redfish access point', check, check, check, check]},
-            {uiData: ['SSH access point', check, check, check, check]},
+            {uiData: ['SSH access point', check, '', '', '']},
             {uiData: ['WebUI access point', check, check, check, check]},
           ];
 


### PR DESCRIPTION
- The interface incorrectly indicates that the Operator, User, and Callback roles have SSH access. In reality, only the Administrator role provides SSH access.
- Defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=685414